### PR TITLE
feat: add rating

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # java-explore-with-me
-Template repository for ExploreWithMe project.
+Repository for ExploreWithMe project.
+https://github.com/Paskoko/java-explore-with-me/pull/3

--- a/ewm-main/src/main/java/ru/practicum/event/EventMapper.java
+++ b/ewm-main/src/main/java/ru/practicum/event/EventMapper.java
@@ -35,6 +35,7 @@ public class EventMapper {
                 .initiator(UserMapper.toUserShortDto(event.getInitiator()))
                 .paid(event.getPaid())
                 .title(event.getTitle())
+                .rating(event.getRating())
                 .views(event.getViews())
                 .build();
     }
@@ -173,6 +174,7 @@ public class EventMapper {
                 .requestModeration(event.isRequestModeration())
                 .state(event.getState())
                 .title(event.getTitle())
+                .rating(event.getRating())
                 .views(event.getViews())
                 .build();
     }

--- a/ewm-main/src/main/java/ru/practicum/event/dto/EventFullDto.java
+++ b/ewm-main/src/main/java/ru/practicum/event/dto/EventFullDto.java
@@ -37,5 +37,7 @@ public class EventFullDto {
     private EventState state;
     @NotBlank
     private String title;
+    private Double rating;
+    private Integer myRating;
     private int views;
 }

--- a/ewm-main/src/main/java/ru/practicum/event/dto/EventShortDto.java
+++ b/ewm-main/src/main/java/ru/practicum/event/dto/EventShortDto.java
@@ -28,5 +28,7 @@ public class EventShortDto {
     private Boolean paid;
     @NotBlank
     private String title;
+    private Double rating;
+    private Integer myRating;
     private int views;
 }

--- a/ewm-main/src/main/java/ru/practicum/event/model/Event.java
+++ b/ewm-main/src/main/java/ru/practicum/event/model/Event.java
@@ -53,5 +53,6 @@ public class Event {
     @Enumerated(EnumType.STRING)
     private EventState state;
     private String title;
+    private Double rating;
     private int views;
 }

--- a/ewm-main/src/main/java/ru/practicum/rating/RatingController.java
+++ b/ewm-main/src/main/java/ru/practicum/rating/RatingController.java
@@ -1,0 +1,63 @@
+package ru.practicum.rating;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import ru.practicum.event.dto.EventFullDto;
+import ru.practicum.event.dto.EventShortDto;
+import ru.practicum.rating.service.RatingService;
+
+import java.util.List;
+
+/**
+ * Class controller for ratings
+ */
+@RestController
+public class RatingController {
+
+    private final RatingService ratingService;
+
+    @Autowired
+    public RatingController(RatingService ratingService) {
+        this.ratingService = ratingService;
+    }
+
+    /**
+     * POST request handler to create new rate for the event
+     *
+     * @param userId  of user
+     * @param eventId of the event
+     * @param rating  1-5
+     * @return rated event
+     */
+    @PostMapping(value = "/users/{userId}/events/{eventId}/rate/{rating}")
+    @ResponseStatus(HttpStatus.CREATED)
+    public EventFullDto createUser(@PathVariable int userId, @PathVariable int eventId, @PathVariable int rating) {
+        return ratingService.setRating(userId, eventId, rating);
+    }
+
+    /**
+     * DELETE request handler to delete rate for the event
+     *
+     * @param userId  of user
+     * @param eventId of event
+     */
+    @DeleteMapping(value = "/users/{userId}/events/{eventId}/rate/delete")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteUser(@PathVariable int userId, @PathVariable int eventId) {
+        ratingService.deleteRating(userId, eventId);
+    }
+
+    /**
+     * GET request handler to get list of user's rated events
+     *
+     * @param userId of user
+     * @return list of events
+     */
+    @GetMapping(value = "/users/{userId}/rates")
+    @ResponseStatus(HttpStatus.OK)
+    public List<EventShortDto> getUserRatingByEvent(@PathVariable int userId) {
+        return ratingService.getUserRatingByEvent(userId);
+    }
+
+}

--- a/ewm-main/src/main/java/ru/practicum/rating/model/Rating.java
+++ b/ewm-main/src/main/java/ru/practicum/rating/model/Rating.java
@@ -1,0 +1,27 @@
+package ru.practicum.rating.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+/**
+ * Class with rating's components
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "ratings")
+public class Rating {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rating_id")
+    private int id;
+    @Column(name = "id_event")
+    private int eventId;
+    private int rating;
+}

--- a/ewm-main/src/main/java/ru/practicum/rating/service/RatingService.java
+++ b/ewm-main/src/main/java/ru/practicum/rating/service/RatingService.java
@@ -1,0 +1,39 @@
+package ru.practicum.rating.service;
+
+import ru.practicum.event.dto.EventFullDto;
+import ru.practicum.event.dto.EventShortDto;
+
+import java.util.List;
+
+/**
+ * Interface for rating service
+ */
+public interface RatingService {
+
+    /**
+     * Set rating for the event
+     *
+     * @param userId      of user
+     * @param eventId     of the event
+     * @param eventRating 1-5
+     * @return rated event
+     */
+    EventFullDto setRating(int userId, int eventId, int eventRating);
+
+    /**
+     * Delete rate for the event
+     *
+     * @param userId  of user
+     * @param eventId of the event
+     * @return event without user's rating
+     */
+    EventFullDto deleteRating(int userId, int eventId);
+
+    /**
+     * Get user's rated events
+     *
+     * @param userId of user
+     * @return list of events
+     */
+    List<EventShortDto> getUserRatingByEvent(int userId);
+}

--- a/ewm-main/src/main/java/ru/practicum/rating/service/RatingServiceImpl.java
+++ b/ewm-main/src/main/java/ru/practicum/rating/service/RatingServiceImpl.java
@@ -1,0 +1,206 @@
+package ru.practicum.rating.service;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ru.practicum.event.EventMapper;
+import ru.practicum.event.dto.EventFullDto;
+import ru.practicum.event.dto.EventShortDto;
+import ru.practicum.event.model.Event;
+import ru.practicum.event.model.QEvent;
+import ru.practicum.event.storage.EventRepository;
+import ru.practicum.rating.model.QRating;
+import ru.practicum.rating.model.Rating;
+import ru.practicum.rating.storage.RatingRepository;
+import ru.practicum.request.model.QRequest;
+import ru.practicum.request.model.Request;
+import ru.practicum.request.model.RequestStatus;
+import ru.practicum.request.storage.RequestRepository;
+import ru.practicum.user.model.User;
+import ru.practicum.user.storage.UserRepository;
+import ru.practicum.util.exception.RequestValidationException;
+import ru.practicum.util.exception.ResourceNotFoundException;
+
+import javax.validation.ValidationException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Class service for operations with ratings storage
+ */
+@Service
+public class RatingServiceImpl implements RatingService {
+
+    private final RatingRepository ratingRepository;
+    private final UserRepository userRepository;
+    private final EventRepository eventRepository;
+    private final RequestRepository requestRepository;
+
+    @Autowired
+    public RatingServiceImpl(RatingRepository ratingRepository, UserRepository userRepository, EventRepository eventRepository, RequestRepository requestRepository) {
+        this.ratingRepository = ratingRepository;
+        this.userRepository = userRepository;
+        this.eventRepository = eventRepository;
+        this.requestRepository = requestRepository;
+    }
+
+
+    /**
+     * Set rating for the event
+     *
+     * @param userId      of user
+     * @param eventId     of the event
+     * @param eventRating 1-5
+     * @return rated event
+     */
+    @Override
+    public EventFullDto setRating(int userId, int eventId, int eventRating) {
+        User user = userRepository.findById(userId).orElseThrow(() ->
+                new ResourceNotFoundException("User with id=" + userId + " was not found."));
+        Event event = eventRepository.findById(eventId).orElseThrow(() ->
+                new ResourceNotFoundException("Event with id=" + eventId + " was not found."));
+        if ((eventRating < 1) || (eventRating > 5)) {
+            throw new ValidationException("Rating should be from 1 to 5.");
+        }
+
+        BooleanExpression byUserId = QRequest.request.requester.id.eq(userId);
+        BooleanExpression byEventId = QRequest.request.event.id.eq(eventId);
+        BooleanExpression byState = QRequest.request.status.eq(RequestStatus.CONFIRMED);
+        List<Request> requests = (List<Request>) requestRepository.findAll(byUserId.and(byEventId).and(byState));
+        if (requests.isEmpty()) {
+            throw new RequestValidationException("User with id=" + userId + " has not visited this event.");
+        }
+
+        Rating newRating = Rating.builder()
+                .eventId(event.getId())
+                .rating(eventRating)
+                .build();
+
+        // Upd user rating list & change rating if user rate event second time -> just update
+        List<Rating> userRatings = user.getUserRatings();
+        userRatings.add(newRating);
+        user.setUserRatings(userRatings);
+        userRepository.save(user);
+        ratingRepository.save(newRating);
+
+
+        BooleanExpression ratingByEvent = QRating.rating1.eventId.eq(eventId);
+        List<Rating> ratingList = (List<Rating>) ratingRepository.findAll(ratingByEvent);
+
+        // Add rating to the event avg rating
+        Double eventAvgRating = event.getRating();
+        int numEventRating = ratingList.size();
+        if (eventAvgRating != null) {
+            eventAvgRating = (eventAvgRating + eventRating) / numEventRating;
+        } else {
+            eventAvgRating = (double) eventRating;
+        }
+        event.setRating(eventAvgRating);
+        eventRepository.save(event);
+
+
+        // Add rating to the event owner avg rating
+        User owner = userRepository.findById(event.getInitiator().getId()).orElseThrow();
+        Double ownerAvgRating = owner.getRating();
+        // Owner rating = avg rating of all his events
+        int numOwnerRatings = countOwnerRatedEvents(owner);
+        if (ownerAvgRating != null) {
+            ownerAvgRating = (ownerAvgRating + eventAvgRating) / numOwnerRatings;
+        } else {
+            ownerAvgRating = eventAvgRating;
+        }
+        owner.setRating(ownerAvgRating);
+        userRepository.save(owner);
+
+        EventFullDto result = EventMapper.toEventFullDto(event);
+        result.setMyRating(eventRating);
+
+        return result;
+    }
+
+
+    /**
+     * Delete rate for the event
+     *
+     * @param userId  of user
+     * @param eventId of the event
+     * @return event without user's rating
+     */
+    @Override
+    public EventFullDto deleteRating(int userId, int eventId) {
+        User user = userRepository.findById(userId).orElseThrow(() ->
+                new ResourceNotFoundException("User with id=" + userId + " was not found."));
+        Event event = eventRepository.findById(eventId).orElseThrow(() ->
+                new ResourceNotFoundException("Event with id=" + eventId + " was not found."));
+
+        // Find and delete rating from user's list and database
+
+        List<Rating> userRatings = user.getUserRatings();
+        Rating deletedRating = userRatings.stream()
+                .filter(r -> r.getEventId() == eventId)
+                .findFirst().get();
+        ratingRepository.delete(deletedRating);
+        userRatings.remove(deletedRating);
+        user.setUserRatings(userRatings);
+        userRepository.save(user);
+
+
+        BooleanExpression ratingByEvent = QRating.rating1.eventId.eq(eventId);
+        List<Rating> ratingList = (List<Rating>) ratingRepository.findAll(ratingByEvent);
+
+        // Delete rating from the event avg rating
+        Double eventAvgRating = event.getRating();
+        eventAvgRating = ratingList.size() * eventAvgRating - deletedRating.getRating();
+        event.setRating(eventAvgRating);
+        eventRepository.save(event);
+
+        // Delete rating from the event owner avg rating
+        User owner = event.getInitiator();
+        Double ownerAvgRating = owner.getRating();
+        int numOwnerRatings = countOwnerRatedEvents(owner);
+        ownerAvgRating = numOwnerRatings * ownerAvgRating - deletedRating.getRating();
+        owner.setRating(ownerAvgRating);
+        userRepository.save(owner);
+
+        EventFullDto result = EventMapper.toEventFullDto(event);
+        result.setMyRating(null);
+
+        return result;
+    }
+
+    /**
+     * Get user's rated events
+     *
+     * @param userId of user
+     * @return list of events
+     */
+    @Override
+    public List<EventShortDto> getUserRatingByEvent(int userId) {
+        User user = userRepository.findById(userId).orElseThrow(() ->
+                new ResourceNotFoundException("User with id=" + userId + " was not found."));
+
+        return user.getUserRatings().stream()
+                .map(rating -> {
+                    int eventId = rating.getEventId();
+                    Event event = eventRepository.findById(eventId).orElseThrow(() ->
+                            new ResourceNotFoundException("Event with id=" + eventId + " was not found."));
+                    EventShortDto eventShortDto = EventMapper.toEventShortDto(event);
+                    eventShortDto.setMyRating(rating.getRating());
+                    return eventShortDto;
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Count rated events for user
+     *
+     * @param owner user
+     * @return number of rated events
+     */
+    private int countOwnerRatedEvents(User owner) {
+        BooleanExpression byUserId = QEvent.event.initiator.id.eq(owner.getId());
+        BooleanExpression byRate = QEvent.event.rating.isNotNull();
+        List<Event> eventList = (List<Event>) eventRepository.findAll(byUserId.and(byRate));
+        return eventList.size();
+    }
+}

--- a/ewm-main/src/main/java/ru/practicum/rating/storage/RatingRepository.java
+++ b/ewm-main/src/main/java/ru/practicum/rating/storage/RatingRepository.java
@@ -1,0 +1,11 @@
+package ru.practicum.rating.storage;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import ru.practicum.rating.model.Rating;
+
+/**
+ * Repository interface for ratings table
+ */
+public interface RatingRepository extends JpaRepository<Rating, Integer>, QuerydslPredicateExecutor<Rating> {
+}

--- a/ewm-main/src/main/java/ru/practicum/request/service/RequestServiceImpl.java
+++ b/ewm-main/src/main/java/ru/practicum/request/service/RequestServiceImpl.java
@@ -80,7 +80,7 @@ public class RequestServiceImpl implements RequestService {
         if ((event.getParticipantLimit() != 0) && (event.getConfirmedRequests() == event.getParticipantLimit())) {
             throw new RequestValidationException("Event participation limit has been reached.");
         }
-        if (event.getParticipantLimit() == 0) {
+        if ((event.getParticipantLimit() == 0) || (!event.isRequestModeration())) {
             newRequest.setStatus(RequestStatus.CONFIRMED);
         }
         event.setConfirmedRequests(event.getConfirmedRequests() + 1);

--- a/ewm-main/src/main/java/ru/practicum/user/UserMapper.java
+++ b/ewm-main/src/main/java/ru/practicum/user/UserMapper.java
@@ -24,6 +24,7 @@ public class UserMapper {
                 .id(user.getId())
                 .email(user.getEmail())
                 .name(user.getName())
+                .rating(user.getRating())
                 .build();
     }
 

--- a/ewm-main/src/main/java/ru/practicum/user/dto/UserDto.java
+++ b/ewm-main/src/main/java/ru/practicum/user/dto/UserDto.java
@@ -18,4 +18,5 @@ public class UserDto {
     private String email;
     @NotBlank
     private String name;
+    private Double rating;
 }

--- a/ewm-main/src/main/java/ru/practicum/user/model/User.java
+++ b/ewm-main/src/main/java/ru/practicum/user/model/User.java
@@ -4,9 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import ru.practicum.rating.model.Rating;
 
 import javax.persistence.*;
 import javax.validation.constraints.Email;
+import java.util.List;
 
 /**
  * Class with user's components
@@ -25,4 +27,10 @@ public class User {
     @Email
     private String email;
     private String name;
+    private Double rating;
+    @ManyToMany(cascade = {CascadeType.ALL})
+    @JoinTable(name = "user_ratings",
+            joinColumns = {@JoinColumn(name = "id_user")},
+            inverseJoinColumns = {@JoinColumn(name = "id_rating")})
+    private List<Rating> userRatings;
 }

--- a/ewm-main/src/main/resources/schema.sql
+++ b/ewm-main/src/main/resources/schema.sql
@@ -4,12 +4,15 @@ DROP TABLE IF EXISTS users,
             event_compilations,
             locations,
             events,
-            requests;
+            requests,
+            ratings,
+            user_ratings;
 
 CREATE TABLE IF NOT EXISTS users(
     user_id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY NOT NULL,
     email varchar(320) NOT NULL,
 	name varchar(320) NOT NULL,
+	rating DOUBLE,
 	CONSTRAINT uq_email UNIQUE (email)
 );
 
@@ -48,6 +51,8 @@ CREATE TABLE IF NOT EXISTS events(
     request_moderation boolean NOT NULL,
     state VARCHAR(30),
     title varchar(120) NOT NULL,
+    rating DOUBLE,
+    my_rating INTEGER,
     views INTEGER
 );
 
@@ -64,3 +69,16 @@ CREATE TABLE IF NOT EXISTS requests(
     id_requester INTEGER REFERENCES users (user_id) ON DELETE CASCADE NOT NULL,
     status VARCHAR(30) NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS ratings(
+    rating_id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY NOT NULL,
+    id_event INTEGER NOT NULL,
+    rating INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS user_ratings(
+    id_user INTEGER REFERENCES users (user_id) NOT NULL,
+    id_rating INTEGER REFERENCES ratings (rating_id) NOT NULL,
+    PRIMARY KEY (id_user, id_rating)
+);
+

--- a/postman/feature.json
+++ b/postman/feature.json
@@ -1,0 +1,1805 @@
+{
+	"info": {
+		"_postman_id": "01a972a7-9d78-4a7f-aa3b-542c9f797f80",
+		"name": "Test Explore With Me - Feature",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "28838320"
+	},
+	"item": [
+		{
+			"name": "Prepare data",
+			"item": [
+				{
+					"name": "Add event owner",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 201 и данные в формате json\", function () {\r",
+									"    pm.response.to.have.status(201);\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const source = JSON.parse(pm.request.body.raw);\r",
+									"const target = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Пользователь должен содержать поля: id, name, email\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('name');\r",
+									"pm.expect(target).to.have.property('email');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.id).to.not.be.null;\r",
+									"    pm.expect(source.name).equal(target.name, 'Имя пользователя должно соответствовать отправленному в запросе');\r",
+									"    pm.expect(source.email).equal(target.email, 'Почта пользователя должна соответствовать отправленной в запросе');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"email\": \"owner@mail.ru\",\r\n  \"name\": \"Owner\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/admin/users",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"admin",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 201 и данные в формате json\", function () {\r",
+									"    pm.response.to.have.status(201);\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const source = JSON.parse(pm.request.body.raw);\r",
+									"const target = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Пользователь должен содержать поля: id, name, email\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('name');\r",
+									"pm.expect(target).to.have.property('email');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.id).to.not.be.null;\r",
+									"    pm.expect(source.name).equal(target.name, 'Имя пользователя должно соответствовать отправленному в запросе');\r",
+									"    pm.expect(source.email).equal(target.email, 'Почта пользователя должна соответствовать отправленной в запросе');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"email\": \"user@mail.ru\",\r\n  \"name\": \"User\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/admin/users",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"admin",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add category #1",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 201 и данные в формате json\", function () {\r",
+									"    pm.response.to.have.status(201);\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const source = JSON.parse(pm.request.body.raw);\r",
+									"const target = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Категория должна содержать поля: id, name\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('name');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.id).to.not.be.null;\r",
+									"    pm.expect(source.name).equal(target.name, 'Название категории должно совпадать с отправленным');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"name\": \"Sport\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/admin/categories",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"admin",
+								"categories"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add category #2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 201 и данные в формате json\", function () {\r",
+									"    pm.response.to.have.status(201);\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const source = JSON.parse(pm.request.body.raw);\r",
+									"const target = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Категория должна содержать поля: id, name\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('name');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.id).to.not.be.null;\r",
+									"    pm.expect(source.name).equal(target.name, 'Название категории должно совпадать с отправленным');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"name\": \"Show\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/admin/categories",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"admin",
+								"categories"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add event #1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 201 и данные в формате json\", function () {\r",
+									"    pm.response.to.have.status(201);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const source = JSON.parse(pm.request.body.raw);\r",
+									"const target = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Событие должно содержать поля: id, title, annotation, category, paid, eventDate, initiator, description, participantLimit, state, createdOn, location, requestModeration\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('title');\r",
+									"pm.expect(target).to.have.property('annotation');\r",
+									"pm.expect(target).to.have.property('category');\r",
+									"pm.expect(target).to.have.property('paid');\r",
+									"pm.expect(target).to.have.property('eventDate');\r",
+									"pm.expect(target).to.have.property('initiator');\r",
+									"pm.expect(target).to.have.property('description');\r",
+									"pm.expect(target).to.have.property('participantLimit');\r",
+									"pm.expect(target).to.have.property('state');\r",
+									"pm.expect(target).to.have.property('createdOn');\r",
+									"pm.expect(target).to.have.property('location');\r",
+									"pm.expect(target).to.have.property('requestModeration');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.id).to.not.be.null;\r",
+									"    pm.expect(target.title).equal(source.title, 'Название события должно соответствовать названию события в запросе');\r",
+									"    pm.expect(target.annotation).equal(source.annotation, 'Аннотация события должна соответствовать аннотации события в запросе');\r",
+									"    pm.expect(target.paid.toString()).equal(source.paid.toString(), 'Стоимость события должна соответствовать стоимости события в запросе');\r",
+									"    pm.expect(target.eventDate).equal(source.eventDate, 'Дата проведения события должна соответствовать дате проведения события в запросе');\r",
+									"    pm.expect(target.description).equal(source.description, 'Описание события должно соответствовать описание события в запросе');\r",
+									"    pm.expect(target.participantLimit.toString()).equal(source.participantLimit.toString(), 'Лимит участников события должно соответствовать лимиту участников события в запросе');\r",
+									"    pm.expect(target.location.lat.toString()).equal(source.location.lat.toString(), 'Широта локации проведения события должна соответствовать широте локации проведения события в запросе');\r",
+									"    pm.expect(target.location.lon.toString()).equal(source.location.lon.toString(), 'Долгота локации проведения события должна соответствовать долготе локации проведения события в запросе');\r",
+									"    pm.expect(target.requestModeration.toString()).equal(source.requestModeration.toString(), 'Необходимость модерации события должна соответствовать необходимости модерации события в запросе');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"annotation\":\"Perferendis sit nesciunt quia. Aliquam provident amet quia beatae facere. Et non ea eligendi. Corporis in reiciendis. Ea corrupti ut eos blanditiis fuga nostrum quod aut. Ad eum ut atque qui maiores.\",\r\n    \"category\":123,\r\n    \"description\":\"Nihil laborum et. Deleniti nemo dolor adipisci. Sed molestiae nesciunt.\\n \\rMinima sit dolores voluptas provident quaerat in doloremque. Quasi quo accusamus doloremque minus debitis corrupti quia consequatur. Neque reiciendis animi ratione dignissimos qui. Veritatis consequatur aut. Molestiae ut aut ut non.\\n \\rUllam eligendi magnam non placeat illum quam. Qui delectus voluptas fugit consectetur sequi laboriosam ipsa. Vel molestiae ratione cupiditate sed ea et. Rem cupiditate et. Recusandae fuga placeat non molestias possimus eum dolor fuga reiciendis.\",\r\n    \"eventDate\":\"2024-03-08 05:01:45\",\r\n    \"location\":\r\n    {\r\n        \"lat\":39.3514,\r\n        \"lon\":173.2741\r\n    },\r\n    \"paid\":\"false\",\r\n    \"participantLimit\":\"296\",\r\n    \"requestModeration\":\"false\",\r\n    \"title\":\"Earum iusto quibusdam.\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "138"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add event #2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 201 и данные в формате json\", function () {\r",
+									"    pm.response.to.have.status(201);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const source = JSON.parse(pm.request.body.raw);\r",
+									"const target = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Событие должно содержать поля: id, title, annotation, category, paid, eventDate, initiator, description, participantLimit, state, createdOn, location, requestModeration\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('title');\r",
+									"pm.expect(target).to.have.property('annotation');\r",
+									"pm.expect(target).to.have.property('category');\r",
+									"pm.expect(target).to.have.property('paid');\r",
+									"pm.expect(target).to.have.property('eventDate');\r",
+									"pm.expect(target).to.have.property('initiator');\r",
+									"pm.expect(target).to.have.property('description');\r",
+									"pm.expect(target).to.have.property('participantLimit');\r",
+									"pm.expect(target).to.have.property('state');\r",
+									"pm.expect(target).to.have.property('createdOn');\r",
+									"pm.expect(target).to.have.property('location');\r",
+									"pm.expect(target).to.have.property('requestModeration');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.id).to.not.be.null;\r",
+									"    pm.expect(target.title).equal(source.title, 'Название события должно соответствовать названию события в запросе');\r",
+									"    pm.expect(target.annotation).equal(source.annotation, 'Аннотация события должна соответствовать аннотации события в запросе');\r",
+									"    pm.expect(target.paid.toString()).equal(source.paid.toString(), 'Стоимость события должна соответствовать стоимости события в запросе');\r",
+									"    pm.expect(target.eventDate).equal(source.eventDate, 'Дата проведения события должна соответствовать дате проведения события в запросе');\r",
+									"    pm.expect(target.description).equal(source.description, 'Описание события должно соответствовать описание события в запросе');\r",
+									"    pm.expect(target.participantLimit.toString()).equal(source.participantLimit.toString(), 'Лимит участников события должно соответствовать лимиту участников события в запросе');\r",
+									"    pm.expect(target.location.lat.toString()).equal(source.location.lat.toString(), 'Широта локации проведения события должна соответствовать широте локации проведения события в запросе');\r",
+									"    pm.expect(target.location.lon.toString()).equal(source.location.lon.toString(), 'Долгота локации проведения события должна соответствовать долготе локации проведения события в запросе');\r",
+									"    pm.expect(target.requestModeration.toString()).equal(source.requestModeration.toString(), 'Необходимость модерации события должна соответствовать необходимости модерации события в запросе');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"annotation\":\"Quam quasi animi et. Et eveniet vero cumque. Blanditiis quia voluptas est temporibus consectetur incidunt. Et nostrum et. Possimus dolorem et ad voluptas autem cupiditate unde numquam perferendis. Quasi voluptatum delectus et nulla id cupiditate perferendis sit.\",\r\n    \"category\":124,\r\n    \"description\":\"Dignissimos delectus quo dolores sit autem. Nihil non debitis exercitationem soluta. Eveniet qui vel et aut enim nemo quia adipisci recusandae. Minima illo consequuntur quam consequatur. Cumque aliquid quis rerum. Iusto commodi error molestiae odio dolorem.\\n \\rAut rerum deleniti. Voluptas est ut iste velit autem quidem totam sit error. Quo autem quidem commodi fugiat ab consequatur.\\n \\rMagni quia qui doloremque ipsam laudantium in cumque. Vero est porro voluptatem. Quis voluptates sit et. Atque aspernatur sint possimus animi. Aliquam non in soluta fuga odio nobis ex harum ipsum.\",\r\n    \"eventDate\":\"2024-03-08 04:49:22\",\r\n    \"location\":{\r\n        \"lat\":-65.4986,\r\n        \"lon\":47.2024\r\n    },\r\n    \"paid\":\"false\",\r\n    \"participantLimit\":\"539\",\r\n    \"requestModeration\":\"false\",\r\n    \"title\":\"Nulla eligendi sit natus vero voluptates necessitatibus fuga quia.\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "138"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Rate events",
+			"item": [
+				{
+					"name": "Set rating to event without request",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"",
+									"pm.test(\"Response status code is 409\", function () {",
+									"    pm.expect(pm.response.code).to.equal(409);",
+									"});",
+									"",
+									"",
+									"pm.test(\"Response has the required fields\", function () {",
+									"    const responseData = pm.response.json();",
+									"    ",
+									"    pm.expect(responseData).to.be.an('object');",
+									"    pm.expect(responseData.status).to.exist;",
+									"    pm.expect(responseData.reason).to.exist;",
+									"    pm.expect(responseData.message).to.exist;",
+									"    pm.expect(responseData.timeStamp).to.exist;",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events/:eventId/rate/5",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events",
+								":eventId",
+								"rate",
+								"5"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								},
+								{
+									"key": "eventId",
+									"value": "107"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Publish event #1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function () {\r",
+									"    pm.response.to.be.ok;    \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const source = JSON.parse(pm.request.body.raw);\r",
+									"const target = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Событие должно содержать поля: id, title, annotation, category, paid, eventDate, initiator, description, participantLimit, state, createdOn, publishedOn, location, requestModeration\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('title');\r",
+									"pm.expect(target).to.have.property('annotation');\r",
+									"pm.expect(target).to.have.property('category');\r",
+									"pm.expect(target).to.have.property('paid');\r",
+									"pm.expect(target).to.have.property('eventDate');\r",
+									"pm.expect(target).to.have.property('initiator');\r",
+									"pm.expect(target).to.have.property('description');\r",
+									"pm.expect(target).to.have.property('participantLimit');\r",
+									"pm.expect(target).to.have.property('state');\r",
+									"pm.expect(target).to.have.property('createdOn');\r",
+									"pm.expect(target).to.have.property('publishedOn');\r",
+									"pm.expect(target).to.have.property('location');\r",
+									"pm.expect(target).to.have.property('requestModeration');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"   \r",
+									"    pm.expect(\"PUBLISHED\").equal(target.state.toString(), 'Статус события должен соответствовать данным в запросе');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Ac",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"stateAction\":\"PUBLISH_EVENT\"}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/admin/events/:eventId",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"admin",
+								"events",
+								":eventId"
+							],
+							"variable": [
+								{
+									"key": "eventId",
+									"value": "107"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Publish event #2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function () {\r",
+									"    pm.response.to.be.ok;    \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const source = JSON.parse(pm.request.body.raw);\r",
+									"const target = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Событие должно содержать поля: id, title, annotation, category, paid, eventDate, initiator, description, participantLimit, state, createdOn, publishedOn, location, requestModeration\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('title');\r",
+									"pm.expect(target).to.have.property('annotation');\r",
+									"pm.expect(target).to.have.property('category');\r",
+									"pm.expect(target).to.have.property('paid');\r",
+									"pm.expect(target).to.have.property('eventDate');\r",
+									"pm.expect(target).to.have.property('initiator');\r",
+									"pm.expect(target).to.have.property('description');\r",
+									"pm.expect(target).to.have.property('participantLimit');\r",
+									"pm.expect(target).to.have.property('state');\r",
+									"pm.expect(target).to.have.property('createdOn');\r",
+									"pm.expect(target).to.have.property('publishedOn');\r",
+									"pm.expect(target).to.have.property('location');\r",
+									"pm.expect(target).to.have.property('requestModeration');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"   \r",
+									"    pm.expect(\"PUBLISHED\").equal(target.state.toString(), 'Статус события должен соответствовать данным в запросе');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Conte",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"stateAction\":\"PUBLISH_EVENT\"}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/admin/events/:eventId",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"admin",
+								"events",
+								":eventId"
+							],
+							"variable": [
+								{
+									"key": "eventId",
+									"value": "108"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add request #1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 201 и данные в формате json\", function () {\r",
+									"    pm.response.to.have.status(201);   \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const target = pm.response.json();\r",
+									"var query = {};\r",
+									"pm.request.url.query.all().forEach((param) => { query[param.key] = param.value});\r",
+									"\r",
+									"pm.test(\"Запрос на участие должен содержать поля: id, requester, event, status, created\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('requester');\r",
+									"pm.expect(target).to.have.property('event');\r",
+									"pm.expect(target).to.have.property('status');\r",
+									"pm.expect(target).to.have.property('created');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"При создании у запроса на участие в событии без модерации должен быть статус CONFIRMED\", function () {\r",
+									"    pm.expect(target.status).equal(\"CONFIRMED\");\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Id ивента в запросе и в ответе должны совпадать\", function () {\r",
+									"    pm.expect(target.event.toString()).equal(query['eventId'].toString());\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/requests?eventId=107",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"requests"
+							],
+							"query": [
+								{
+									"key": "eventId",
+									"value": "107"
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add request #2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 201 и данные в формате json\", function () {\r",
+									"    pm.response.to.have.status(201);   \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const target = pm.response.json();\r",
+									"var query = {};\r",
+									"pm.request.url.query.all().forEach((param) => { query[param.key] = param.value});\r",
+									"\r",
+									"pm.test(\"Запрос на участие должен содержать поля: id, requester, event, status, created\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('requester');\r",
+									"pm.expect(target).to.have.property('event');\r",
+									"pm.expect(target).to.have.property('status');\r",
+									"pm.expect(target).to.have.property('created');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"При создании у запроса на участие в событии без модерации должен быть статус CONFIRMED\", function () {\r",
+									"    pm.expect(target.status).equal(\"CONFIRMED\");\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Id ивента в запросе и в ответе должны совпадать\", function () {\r",
+									"    pm.expect(target.event.toString()).equal(query['eventId'].toString());\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/requests?eventId=108",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"requests"
+							],
+							"query": [
+								{
+									"key": "eventId",
+									"value": "108"
+								}
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Rate event #1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 201 и данные в формате json\", function () {\r",
+									"    pm.response.to.have.status(201);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const target = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Событие должно содержать поля: id, title, annotation, category, paid, eventDate, initiator, description, participantLimit, state, createdOn, location, requestModeration, rating, myRating\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('title');\r",
+									"pm.expect(target).to.have.property('annotation');\r",
+									"pm.expect(target).to.have.property('category');\r",
+									"pm.expect(target).to.have.property('paid');\r",
+									"pm.expect(target).to.have.property('eventDate');\r",
+									"pm.expect(target).to.have.property('initiator');\r",
+									"pm.expect(target).to.have.property('description');\r",
+									"pm.expect(target).to.have.property('participantLimit');\r",
+									"pm.expect(target).to.have.property('state');\r",
+									"pm.expect(target).to.have.property('createdOn');\r",
+									"pm.expect(target).to.have.property('location');\r",
+									"pm.expect(target).to.have.property('requestModeration');\r",
+									"pm.expect(target).to.have.property('rating');\r",
+									"pm.expect(target).to.have.property('myRating');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.rating).equal(5.0, 'Рейтинг события должен учитывать оценку в запросе');\r",
+									"    pm.expect(target.myRating).equal(5, 'Оценка пользователя должна соответствовать оценке в запросе');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events/:eventId/rate/5",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events",
+								":eventId",
+								"rate",
+								"5"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								},
+								{
+									"key": "eventId",
+									"value": "107"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Rate event #2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 201 и данные в формате json\", function () {\r",
+									"    pm.response.to.have.status(201);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const target = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Событие должно содержать поля: id, title, annotation, category, paid, eventDate, initiator, description, participantLimit, state, createdOn, location, requestModeration, rating, myRating\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('title');\r",
+									"pm.expect(target).to.have.property('annotation');\r",
+									"pm.expect(target).to.have.property('category');\r",
+									"pm.expect(target).to.have.property('paid');\r",
+									"pm.expect(target).to.have.property('eventDate');\r",
+									"pm.expect(target).to.have.property('initiator');\r",
+									"pm.expect(target).to.have.property('description');\r",
+									"pm.expect(target).to.have.property('participantLimit');\r",
+									"pm.expect(target).to.have.property('state');\r",
+									"pm.expect(target).to.have.property('createdOn');\r",
+									"pm.expect(target).to.have.property('location');\r",
+									"pm.expect(target).to.have.property('requestModeration');\r",
+									"pm.expect(target).to.have.property('rating');\r",
+									"pm.expect(target).to.have.property('myRating');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.rating).equal(4.0, 'Рейтинг события должен учитывать оценку в запросе');\r",
+									"    pm.expect(target.myRating).equal(4, 'Оценка пользователя должна соответствовать оценке в запросе');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events/:eventId/rate/4",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events",
+								":eventId",
+								"rate",
+								"4"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								},
+								{
+									"key": "eventId",
+									"value": "108"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Check ratings",
+			"item": [
+				{
+					"name": "Check user's rates",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function () {\r",
+									"    pm.response.to.be.ok;    \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const target = pm.response.json()[0];\r",
+									"\r",
+									"pm.test(\"Событие должно содержать поля: id, title, annotation, category, paid, eventDate, initiator, views, confirmedRequests, rating, myRating\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('title');\r",
+									"pm.expect(target).to.have.property('annotation');\r",
+									"pm.expect(target).to.have.property('category');\r",
+									"pm.expect(target).to.have.property('paid');\r",
+									"pm.expect(target).to.have.property('eventDate');\r",
+									"pm.expect(target).to.have.property('initiator');\r",
+									"pm.expect(target).to.have.property('views');\r",
+									"pm.expect(target).to.have.property('confirmedRequests');\r",
+									"pm.expect(target).to.have.property('rating');\r",
+									"pm.expect(target).to.have.property('myRating');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.rating).equal(5.0, 'Рейтинг события должен учитывать оценку в запросе');\r",
+									"    pm.expect(target.myRating).equal(5, 'Оценка пользователя должна соответствовать оценке в запросе');\r",
+									"});\r",
+									"\r",
+									"const second = pm.response.json()[1];\r",
+									"\r",
+									"pm.test(\"Событие должно содержать поля: id, title, annotation, category, paid, eventDate, initiator, views, confirmedRequests, rating, myRating\", function () {\r",
+									"pm.expect(second).to.have.property('id');\r",
+									"pm.expect(second).to.have.property('title');\r",
+									"pm.expect(second).to.have.property('annotation');\r",
+									"pm.expect(second).to.have.property('category');\r",
+									"pm.expect(second).to.have.property('paid');\r",
+									"pm.expect(second).to.have.property('eventDate');\r",
+									"pm.expect(second).to.have.property('initiator');\r",
+									"pm.expect(second).to.have.property('views');\r",
+									"pm.expect(second).to.have.property('confirmedRequests');\r",
+									"pm.expect(second).to.have.property('rating');\r",
+									"pm.expect(second).to.have.property('myRating');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(second.rating).equal(4.0, 'Рейтинг события должен учитывать оценку в запросе');\r",
+									"    pm.expect(second.myRating).equal(4, 'Оценка пользователя должна соответствовать оценке в запросе');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/rates",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"rates"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Check owner's rating by admin",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function () {\r",
+									"    pm.response.to.be.ok;    \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const target = pm.response.json()[0];\r",
+									"\r",
+									"pm.test(\"Событие должно содержать поля: id, email, name, rating\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('email');\r",
+									"pm.expect(target).to.have.property('name');\r",
+									"pm.expect(target).to.have.property('rating');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.rating).equal(4.5, 'Рейтинг владельца должен быть верным');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/admin/users?ids=138",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"admin",
+								"users"
+							],
+							"query": [
+								{
+									"key": "ids",
+									"value": "138"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete rate #2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 204\", function () {\r",
+									"    pm.response.to.have.status(204);  \r",
+									"});\r",
+									"\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events/:eventId/rate/delete",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events",
+								":eventId",
+								"rate",
+								"delete"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								},
+								{
+									"key": "eventId",
+									"value": "108"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Check user's rates #2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function () {\r",
+									"    pm.response.to.be.ok;    \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const target = pm.response.json()[0];\r",
+									"\r",
+									"pm.test(\"Событие должно содержать поля: id, title, annotation, category, paid, eventDate, initiator, views, confirmedRequests, rating, myRating\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('title');\r",
+									"pm.expect(target).to.have.property('annotation');\r",
+									"pm.expect(target).to.have.property('category');\r",
+									"pm.expect(target).to.have.property('paid');\r",
+									"pm.expect(target).to.have.property('eventDate');\r",
+									"pm.expect(target).to.have.property('initiator');\r",
+									"pm.expect(target).to.have.property('views');\r",
+									"pm.expect(target).to.have.property('confirmedRequests');\r",
+									"pm.expect(target).to.have.property('rating');\r",
+									"pm.expect(target).to.have.property('myRating');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.rating).equal(5.0, 'Рейтинг события должен учитывать оценку в запросе');\r",
+									"    pm.expect(target.myRating).equal(5, 'Оценка пользователя должна соответствовать оценке в запросе');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/rates",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"rates"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Check owner's rating by admin #2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 200 и данные в формате json\", function () {\r",
+									"    pm.response.to.be.ok;    \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const target = pm.response.json()[0];\r",
+									"\r",
+									"pm.test(\"Событие должно содержать поля: id, email, name, rating\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('email');\r",
+									"pm.expect(target).to.have.property('name');\r",
+									"pm.expect(target).to.have.property('rating');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.rating).equal(5.0, 'Рейтинг владельца должен быть верным');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/admin/users?ids=138",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"admin",
+								"users"
+							],
+							"query": [
+								{
+									"key": "ids",
+									"value": "138"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Validation",
+			"item": [
+				{
+					"name": "Rate event with wrong user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 404\", function () {\r",
+									"    pm.response.to.have.status(404);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events/:eventId/rate/5",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events",
+								":eventId",
+								"rate",
+								"5"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "140"
+								},
+								{
+									"key": "eventId",
+									"value": "107"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Rate event with wrong event",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 404\", function () {\r",
+									"    pm.response.to.have.status(404);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events/:eventId/rate/5",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events",
+								":eventId",
+								"rate",
+								"5"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								},
+								{
+									"key": "eventId",
+									"value": "1111"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Rate event with rate 0",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 400\", function () {\r",
+									"    pm.response.to.have.status(400);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events/:eventId/rate/0",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events",
+								":eventId",
+								"rate",
+								"0"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								},
+								{
+									"key": "eventId",
+									"value": "107"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Rate event with rate 6",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 400\", function () {\r",
+									"    pm.response.to.have.status(400);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events/:eventId/rate/6",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events",
+								":eventId",
+								"rate",
+								"6"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								},
+								{
+									"key": "eventId",
+									"value": "107"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add user #3",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 201 и данные в формате json\", function () {\r",
+									"    pm.response.to.have.status(201);\r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});\r",
+									"\r",
+									"const source = JSON.parse(pm.request.body.raw);\r",
+									"const target = pm.response.json();\r",
+									"\r",
+									"pm.test(\"Пользователь должен содержать поля: id, name, email\", function () {\r",
+									"pm.expect(target).to.have.property('id');\r",
+									"pm.expect(target).to.have.property('name');\r",
+									"pm.expect(target).to.have.property('email');\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Данные в ответе должны соответствовать данным в запросе\", function () {\r",
+									"    pm.expect(target.id).to.not.be.null;\r",
+									"    pm.expect(source.name).equal(target.name, 'Имя пользователя должно соответствовать отправленному в запросе');\r",
+									"    pm.expect(source.email).equal(target.email, 'Почта пользователя должна соответствовать отправленной в запросе');\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"email\": \"test@mail.ru\",\r\n  \"name\": \"test user\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/admin/users",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"admin",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Rate not visited event",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 409\", function () {\r",
+									"    pm.response.to.have.status(409);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events/:eventId/rate/1",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events",
+								":eventId",
+								"rate",
+								"1"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "140"
+								},
+								{
+									"key": "eventId",
+									"value": "107"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete rate with wrong user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 404\", function () {\r",
+									"    pm.response.to.have.status(404);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events/:eventId/rate/delete",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events",
+								":eventId",
+								"rate",
+								"delete"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "150"
+								},
+								{
+									"key": "eventId",
+									"value": "108"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete rate with wrong event",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 404\", function () {\r",
+									"    pm.response.to.have.status(404);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/events/:eventId/rate/delete",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"events",
+								":eventId",
+								"rate",
+								"delete"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "139"
+								},
+								{
+									"key": "eventId",
+									"value": "999"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Check user's rates wrong user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Ответ должен содержать код статуса 404\", function () {\r",
+									"    pm.response.to.have.status(404);  \r",
+									"    pm.response.to.be.withBody;\r",
+									"    pm.response.to.be.json;\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/users/:userId/rates",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								":userId",
+								"rates"
+							],
+							"variable": [
+								{
+									"key": "userId",
+									"value": "999"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "http://localhost:8080",
+			"type": "string"
+		},
+		{
+			"key": "ownerId",
+			"value": "136",
+			"type": "string"
+		},
+		{
+			"key": "watcherId",
+			"value": "137",
+			"type": "string"
+		},
+		{
+			"key": "event1Id",
+			"value": "104",
+			"type": "string"
+		},
+		{
+			"key": "event2Id",
+			"value": "105",
+			"type": "string"
+		},
+		{
+			"key": "category1Id",
+			"value": "121",
+			"type": "string"
+		},
+		{
+			"key": "category2Id",
+			"value": "122",
+			"type": "string"
+		}
+	]
+}


### PR DESCRIPTION
Add rating feature. Rating from 1 to 5, only to visited events. Delete rating. User can check visited events with avg rating and personal rating. Admin can check event's owner rating, based on his events ratings. 